### PR TITLE
[ITSP-116] remove mutagen from install script and add sudo

### DIFF
--- a/Formula/support/sail/install
+++ b/Formula/support/sail/install
@@ -21,13 +21,7 @@ function pull_sail() {
 
 function install() {
   if pull_sail ; then
-    ln -s "$HOME/.sail/.source/support/sail_exec" /usr/local/bin/sail
-
-    unzip "$HOME/.sail/.source/support/mutagen.zip" -d "$HOME/.sail/.source/support/bin/"
-    arch=$(uname -m)
-    ln -s "$HOME/.sail/.source/support/bin/mutagen-$arch" /usr/local/bin/mutagen
-    ln -s "$HOME/.sail/.source/support/bin/mutagen-compose-$arch" /usr/local/bin/mutagen-compose
-
+    sudo ln -s "$HOME/.sail/.source/support/sail_exec" /usr/local/bin/sail
     echo -e "${BLUE}sail: ${GREEN}Success! ${NC}"
   fi
 }


### PR DESCRIPTION
## What

Removing the mutagen ln commands

## Why

Mutagen should not be installed alongside sail.

## Testing

Uninstall sail `rm -rf /usr/local/bin/sail && rm -rf "$HOME/.sail"`
then run `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/snapsheet/homebrew-dev/ITSP-116_remove_mutagent_from_install_script_and_add_sudo/Formula/support/sail/install)"`

## Expected result

sail will install without extracting the zip archive and creating symbolic links to the mutagen binaries
