### PR TITLE
ITSP-145 initialize update check file on install

### DIFF
--- a/Formula/support/sail/install
+++ b/Formula/support/sail/install
@@ -10,18 +10,22 @@ NC="\033[0m"
 RED="\033[31m"
 ####################################
 
+SAIL_HOME="$HOME/.sail"
+UPDATE_CHECK_TRACK_FILENAME="$SAIL_HOME/update-last-check"
+
 ####################################
 # functions
 ####################################
 
 function pull_sail() {
-  mkdir -p "$HOME/.sail/.source/"
-  git clone git@github.com:bodyshopbidsdotcom/sail.git "$HOME/.sail/.source/"
+  mkdir -p "$SAIL_HOME/.source/"
+  git clone git@github.com:bodyshopbidsdotcom/sail.git "$SAIL_HOME/.source/"
 }
 
 function install() {
   if pull_sail ; then
-    sudo ln -s "$HOME/.sail/.source/support/sail_exec" /usr/local/bin/sail
+    sudo ln -s "$SAIL_HOME/.source/support/sail_exec" /usr/local/bin/sail
+    touch "$UPDATE_CHECK_TRACK_FILENAME"
     echo -e "${BLUE}sail: ${GREEN}Success! ${NC}"
   fi
 }


### PR DESCRIPTION
# What

Initialize update check file when sail is installed

Also made use of `$SAIL_HOME` variable.

# How to test

- `sail uninstall`
- `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/snapsheet/homebrew-dev/ITSP-145-update-check/Formula/support/sail/install)"`
- `git -C "$HOME/.sail/.source/" switch ITSP-145-update-check`
- `sail ready`

You should not be prompted to update sail before `sail ready` is actually performed.